### PR TITLE
Fix production deloyment

### DIFF
--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -83,7 +83,7 @@ resource "kubernetes_deployment" "backend" {
         init_container {
           name    = "${var.application_name}-migrate"
           image   = "${var.image_repository}-backend:${var.tag}"
-          command = ["sh", "-c", "php artisan db:create && php artisan migrate"]
+          command = ["sh", "-c", "php artisan db:create && php artisan migrate --force"]
 
           env_from {
             config_map_ref {


### PR DESCRIPTION
- [x] This change is tested in the PR deployment environment

Blijkbaar kan je geen migrate doen in een productie omgeving (productie deployment met LARAVEL_ENV=production). Maar wij hebben migraties al eerder getest dus is deze check niet nodig.
https://laravel.com/docs/11.x/migrations#forcing-migrations-to-run-in-production
